### PR TITLE
feat(docker): upgrade Publish-Docker-Github-Action

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -38,7 +38,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Publish minimal image to registry
-        uses: elgohr/Publish-Docker-Github-Action@8217e91c0369a5342a4ef2d612de87492410a666 # master
+        uses: elgohr/Publish-Docker-Github-Action@eb53b3ec07136a6ebaed78d8135806da64f7c7e2 # v5
         with:
           name: flanksource/base-image
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
The previous version didn't support `platforms` arg.

`Warning: Unexpected input(s) 'platforms', valid inputs are ['entryPoint', 'args', 'name', 'username', 'password', 'registry', 'snapshot', 'default_branch', 'dockerfile', 'workdir', 'context', 'buildargs', 'buildoptions', 'cache', 'tags', 'tag_names', 'tag_semver', 'no_push']`