### PR TITLE
fix: pip error in canary-checker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,7 @@ RUN --mount=from=installer-env,target=/mnt/pwsh,source=/tmp \
     chmod +x /opt/powershell/pwsh && \
     ln -s /opt/powershell/pwsh /usr/bin/pwsh && \
     # install module outsize of powershell due to segfaults on emulated arm
-    curl -L -o powershell-yaml.nupkg https://psg-prod-eastus.azureedge.net/packages/powershell-yaml.0.4.7.nupkg  && \
+    curl -L -o powershell-yaml.nupkg https://www.powershellgallery.com/api/v2/package/powershell-yaml/0.4.7  && \
     mkdir -p $HOME/.local/share/powershell/Modules/powershell-yaml/0.4.7 && \
     unzip powershell-yaml.nupkg -x */.rels *.nuspec *.xml -d $HOME/.local/share/powershell/Modules/powershell-yaml/0.4.7 && \
     rm powershell-yaml.nupkg && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,7 @@ RUN --mount=from=installer-env,target=/mnt/pwsh,source=/tmp \
 FROM base AS gcloud-installer
 
 ENV GCLOUD_PATH=/opt/google-cloud-sdk
-ENV PATH $GCLOUD_PATH/bin:$PATH
+ENV PATH=$GCLOUD_PATH/bin:$PATH
 ENV CLOUDSDK_PYTHON=/usr/bin/python3
 # Download and install cloud sdk. Review the components I install, you may not need them.
 RUN GCLOUDCLI_URL="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-x86_64.tar.gz" && \
@@ -120,7 +120,7 @@ RUN update-locale LANG=en_US.UTF-8
 
 RUN apt-get install -y locales locales-all
 
-ENV PATH /opt/google-cloud-sdk/bin:$PATH
+ENV PATH=/opt/google-cloud-sdk/bin:$PATH
 ENV CLOUDSDK_PYTHON=/usr/bin/python3
 COPY --from=gcloud-installer /opt/google-cloud-sdk /opt/google-cloud-sdk
 # This is to be able to update gcloud packages

--- a/Dockerfile.canary-checker
+++ b/Dockerfile.canary-checker
@@ -4,7 +4,7 @@ ARG TARGETARCH
 WORKDIR /app
 
 RUN apt-get update && \
-  apt-get install -y python3 python3-full python3-pip zip --no-install-recommends && \
+  apt-get install -y python3 python3-full python3-pip pipx zip --no-install-recommends && \
   rm -Rf /var/lib/apt/lists/*  && \
   rm -Rf /usr/share/doc && rm -Rf /usr/share/man  && \
   apt-get clean && \

--- a/Dockerfile.canary-checker
+++ b/Dockerfile.canary-checker
@@ -1,4 +1,4 @@
-FROM flanksource/base-image as base
+FROM flanksource/base-image AS base
 ARG TARGETARCH
 
 WORKDIR /app
@@ -9,7 +9,7 @@ RUN apt-get update && \
   rm -Rf /usr/share/doc && rm -Rf /usr/share/man  && \
   apt-get clean
 
-FROM base as jre
+FROM base AS jre
 
 ENV SDKMAN_DIR="/usr/lib/sdkman"
 
@@ -42,9 +42,9 @@ ENV JAVA_HOME=/opt/java
 ENV JMETER_HOME=/opt/jmeter
 COPY --from=jre /javaruntime $JAVA_HOME
 COPY --from=jre /usr/lib/sdkman/candidates/jmeter/current /opt/jmeter
-ENV PATH "${JAVA_HOME}/bin:${JMETER_HOME}/bin:${PATH}"
+ENV PATH="${JAVA_HOME}/bin:${JMETER_HOME}/bin:${PATH}"
 
-RUN pip3 install  pip pyyaml lxml requests robotframework \
+RUN pip3 install --break-system-packages pip pyyaml lxml requests robotframework \
     robotframework \
     robotframework-jsonlibrary \
     robotframework-jsonschemalibrary \

--- a/Dockerfile.canary-checker
+++ b/Dockerfile.canary-checker
@@ -4,10 +4,11 @@ ARG TARGETARCH
 WORKDIR /app
 
 RUN apt-get update && \
-  apt-get install -y python3 python3-pip zip --no-install-recommends && \
+  apt-get install -y python3 python3-full python3-pip zip --no-install-recommends && \
   rm -Rf /var/lib/apt/lists/*  && \
   rm -Rf /usr/share/doc && rm -Rf /usr/share/man  && \
-  apt-get clean
+  apt-get clean && \
+  pipx install pipenv
 
 FROM base AS jre
 
@@ -43,20 +44,6 @@ ENV JMETER_HOME=/opt/jmeter
 COPY --from=jre /javaruntime $JAVA_HOME
 COPY --from=jre /usr/lib/sdkman/candidates/jmeter/current /opt/jmeter
 ENV PATH="${JAVA_HOME}/bin:${JMETER_HOME}/bin:${PATH}"
-
-RUN pip3 install --break-system-packages pip pyyaml lxml requests robotframework \
-    robotframework \
-    robotframework-jsonlibrary \
-    robotframework-jsonschemalibrary \
-    robotframework-requests \
-    robotframework-restlibrary \
-    robotframework-seleniumlibrary \
-    robotframework-excellib \
-    robotframework-crypto \
-    robotframework-databaselibrary \
-    psycopg2-binary \
-    PyMySQL && \
-    pip3 cache purge
 
 # Restic
 ENV RESTIC_VERSION=0.15.2


### PR DESCRIPTION
```

#13 [stage-2 3/8] RUN pip3 install  pip pyyaml lxml requests robotframework     robotframework     robotframework-jsonlibrary     robotframework-jsonschemalibrary     robotframework-requests     robotframework-restlibrary     robotframework-seleniumlibrary     robotframework-excellib     robotframework-crypto     robotframework-databaselibrary     psycopg2-binary     PyMySQL &&     pip3 cache purge
#13 0.326 error: externally-managed-environment
#13 0.326 
#13 0.326 × This environment is externally managed
#13 0.326 ╰─> To install Python packages system-wide, try apt install
#13 0.326     python3-xyz, where xyz is the package you are trying to
#13 0.326     install.
#13 0.326     
#13 0.326     If you wish to install a non-Debian-packaged Python package,
#13 0.326     create a virtual environment using python3 -m venv path/to/venv.
#13 0.326     Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
#13 0.326     sure you have python3-full installed.
#13 0.326     
#13 0.326     If you wish to install a non-Debian packaged Python application,
#13 0.326     it may be easiest to use pipx install xyz, which will manage a
#13 0.326     virtual environment for you. Make sure you have pipx installed.
#13 0.326     
#13 0.326     See /usr/share/doc/python3.12/README.venv for more information.
#13 0.326 
#13 0.326 note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
#13 0.326 hint: See PEP 668 for the detailed specification.
#13 ERROR: process "/bin/sh -c pip3 install  pip pyyaml lxml requests robotframework     robotframework     robotframework-jsonlibrary     robotframework-jsonschemalibrary     robotframework-requests     robotframework-restlibrary     robotframework-seleniumlibrary     robotframework-excellib     robotframework-crypto     robotframework-databaselibrary     psycopg2-binary     PyMySQL &&     pip3 cache purge" did not complete successfully: exit code: 1
------
 > [stage-2 3/8] RUN pip3 install  pip pyyaml lxml requests robotframework     robotframework     robotframework-jsonlibrary     robotframework-jsonschemalibrary     robotframework-requests     robotframework-restlibrary     robotframework-seleniumlibrary     robotframework-excellib     robotframework-crypto     robotframework-databaselibrary     psycopg2-binary     PyMySQL &&     pip3 cache purge:
0.326     sure you have python3-full installed.
0.326     
0.326     If you wish to install a non-Debian packaged Python application,
0.326     it may be easiest to use pipx install xyz, which will manage a
0.326     virtual environment for you. Make sure you have pipx installed.
0.326     
0.326     See /usr/share/doc/python3.12/README.venv for more information.
0.326 
0.326 note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
0.326 hint: See PEP 668 for the detailed specification.
------

 3 warnings found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 12)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 45)
Dockerfile.canary-checker:47
--------------------
  46 |     
  47 | >>> RUN pip3 install  pip pyyaml lxml requests robotframework \
  48 | >>>     robotframework \
  49 | >>>     robotframework-jsonlibrary \
  50 | >>>     robotframework-jsonschemalibrary \
  51 | >>>     robotframework-requests \
  52 | >>>     robotframework-restlibrary \
  53 | >>>     robotframework-seleniumlibrary \
  54 | >>>     robotframework-excellib \
  55 | >>>     robotframework-crypto \
  56 | >>>     robotframework-databaselibrary \
  57 | >>>     psycopg2-binary \
  58 | >>>     PyMySQL && \
  59 | >>>     pip3 cache purge
  60 |     
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c pip3 install  pip pyyaml lxml requests robotframework     robotframework     robotframework-jsonlibrary     robotframework-jsonschemalibrary     robotframework-requests     robotframework-restlibrary     robotframework-seleniumlibrary     robotframework-excellib     robotframework-crypto     robotframework-databaselibrary     psycopg2-binary     PyMySQL &&     pip3 cache purge" did not complete successfully: exit code: 1
Reference
  builder-c8fcdf8e-d32e-453b-bd67-9cc09667d859/builder-c8fcdf8e-d32e-453b-bd67-9cc09667d8590/rijzdppx73zme1qkwu8gm7rb7
Check build summary support
  Build summary supported!
8m 59s

#11 [stage-2 1/8] COPY --from=jre /javaruntime /opt/java
#11 DONE 0.3s

#12 [stage-2 2/8] COPY --from=jre /usr/lib/sdkman/candidates/jmeter/current /opt/jmeter
#12 DONE 0.2s

#13 [stage-2 3/8] RUN pip3 install  pip pyyaml lxml requests robotframework     robotframework     robotframework-jsonlibrary     robotframework-jsonschemalibrary     robotframework-requests     robotframework-restlibrary     robotframework-seleniumlibrary     robotframework-excellib     robotframework-crypto     robotframework-databaselibrary     psycopg2-binary     PyMySQL &&     pip3 cache purge
#13 0.326 error: externally-managed-environment
#13 0.326 
#13 0.326 × This environment is externally managed
#13 0.326 ╰─> To install Python packages system-wide, try apt install
#13 0.326     python3-xyz, where xyz is the package you are trying to
#13 0.326     install.
#13 0.326     
#13 0.326     If you wish to install a non-Debian-packaged Python package,
#13 0.326     create a virtual environment using python3 -m venv path/to/venv.
#13 0.326     Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
#13 0.326     sure you have python3-full installed.
#13 0.326     
#13 0.326     If you wish to install a non-Debian packaged Python application,
#13 0.326     it may be easiest to use pipx install xyz, which will manage a
#13 0.326     virtual environment for you. Make sure you have pipx installed.
#13 0.326     
#13 0.326     See /usr/share/doc/python3.12/README.venv for more information.
#13 0.326 
#13 0.326 note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
#13 0.326 hint: See PEP 668 for the detailed specification.
#13 ERROR: process "/bin/sh -c pip3 install  pip pyyaml lxml requests robotframework     robotframework     robotframework-jsonlibrary     robotframework-jsonschemalibrary     robotframework-requests     robotframework-restlibrary     robotframework-seleniumlibrary     robotframework-excellib     robotframework-crypto     robotframework-databaselibrary     psycopg2-binary     PyMySQL &&     pip3 cache purge" did not complete successfully: exit code: 1
------
 > [stage-2 3/8] RUN pip3 install  pip pyyaml lxml requests robotframework     robotframework     robotframework-jsonlibrary     robotframework-jsonschemalibrary     robotframework-requests     robotframework-restlibrary     robotframework-seleniumlibrary     robotframework-excellib     robotframework-crypto     robotframework-databaselibrary     psycopg2-binary     PyMySQL &&     pip3 cache purge:
0.326     sure you have python3-full installed.
0.326     
0.326     If you wish to install a non-Debian packaged Python application,
0.326     it may be easiest to use pipx install xyz, which will manage a
0.326     virtual environment for you. Make sure you have pipx installed.
0.326     
0.326     See /usr/share/doc/python3.12/README.venv for more information.
0.326 
0.326 note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
0.326 hint: See PEP 668 for the detailed specification.
------

 3 warnings found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 12)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 45)
Dockerfile.canary-checker:47
--------------------
  46 |     
  47 | >>> RUN pip3 install  pip pyyaml lxml requests robotframework \
  48 | >>>     robotframework \
  49 | >>>     robotframework-jsonlibrary \
  50 | >>>     robotframework-jsonschemalibrary \
  51 | >>>     robotframework-requests \
  52 | >>>     robotframework-restlibrary \
  53 | >>>     robotframework-seleniumlibrary \
  54 | >>>     robotframework-excellib \
  55 | >>>     robotframework-crypto \
  56 | >>>     robotframework-databaselibrary \
  57 | >>>     psycopg2-binary \
  58 | >>>     PyMySQL && \
  59 | >>>     pip3 cache purge
  60 |     
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c pip3 install  pip pyyaml lxml requests robotframework     robotframework     robotframework-jsonlibrary     robotframework-jsonschemalibrary     robotframework-requests     robotframework-restlibrary     robotframework-seleniumlibrary     robotframework-excellib     robotframework-crypto     robotframework-databaselibrary     psycopg2-binary     PyMySQL &&     pip3 cache purge" did not complete successfully: exit code: 1
Reference
  builder-c8fcdf8e-d32e-453b-bd67-9cc09667d859/builder-c8fcdf8e-d32e-453b-bd67-9cc09667d8590/rijzdppx73zme1qkwu8gm7rb7
Check build summary support
  Build summary supported!
Error: buildx failed with: ERROR: failed to build: failed to solve: process "/bin/sh -c pip3 install  pip pyyaml lxml requests robotframework     robotframework     robotframework-jsonlibrary     robotframework-jsonschemalibrary     robotframework-requests     robotframework-restlibrary     robotframework-seleniumlibrary     robotframework-excellib     robotframework-crypto     robotframework-databaselibrary     psycopg2-binary     PyMySQL &&     pip3 cache purge" did not complete successfully: exit code: 1
```