### PR TITLE
feat: add PR tests with canary-checker self-test fixtures

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,93 +6,46 @@ permissions:
   contents: read
 
 jobs:
-  docker-build-amd64:
-    runs-on: ubuntu-latest
+  test:
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { arch: amd64, runner: ubuntu-latest, image: base-image, dockerfile: Dockerfile }
+          - { arch: amd64, runner: ubuntu-latest, image: base-image-canary-checker, dockerfile: Dockerfile.canary-checker }
+          - { arch: arm64, runner: ubuntu-24.04-arm, image: base-image, dockerfile: Dockerfile }
+          - { arch: arm64, runner: ubuntu-24.04-arm, image: base-image-canary-checker, dockerfile: Dockerfile.canary-checker }
     steps:
-      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions/checkout@v4
 
       - name: Set version
-        # Set a random release version
         run: |
           echo "RELEASE_VERSION=$(tr -dc 0-9 </dev/urandom | head -c 4)" >> $GITHUB_ENV
 
-      - name: Set up Docker Buildx #must be executed before a step that contains platforms
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build base image for multiple platforms
-        # Need to build for 2 platforms in 2 stages even though --platform=linux/amd64,linux/arm64 is possible.
-        # This is because --load isn't compatible when multiple args are passed to --platform.
-        #   https://github.com/docker/buildx/issues/59
-        # We want --load to save the image to local registry.
+      - name: Build image
         run: |
-          docker buildx build --load --platform linux/amd64 --cache-from type=gha --cache-to type=gha,mode=max --secret id=GITHUB_TOKEN,env=GITHUB_TOKEN -t flanksource/base-image:${{ env.RELEASE_VERSION }} .
+          docker buildx build --load --platform linux/${{ matrix.arch }} \
+            --cache-from type=gha --cache-to type=gha,mode=max \
+            --secret id=GITHUB_TOKEN,env=GITHUB_TOKEN \
+            -f ${{ matrix.dockerfile }} \
+            -t flanksource/${{ matrix.image }}:${{ env.RELEASE_VERSION }} .
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run the container
+      - name: Run basic test
         run: |
-          docker run --pull=never --rm flanksource/base-image:${{ env.RELEASE_VERSION }} echo 'hello world'
+          docker run --pull=never --rm flanksource/${{ matrix.image }}:${{ env.RELEASE_VERSION }} echo 'hello world'
 
-      - name: Build canary checker base image for multiple platforms
+      - name: Install canary-checker and run self-tests
         run: |
-          docker buildx build --load --platform linux/amd64 --cache-from type=gha --cache-to type=gha,mode=max --secret id=GITHUB_TOKEN,env=GITHUB_TOKEN -f Dockerfile.canary-checker -t flanksource/base-image-canary-checker:${{ env.RELEASE_VERSION }} .
+          docker run --pull=never --rm \
+            -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+            -v ${{ github.workspace }}/fixtures/selftest:/fixtures:ro \
+            flanksource/${{ matrix.image }}:${{ env.RELEASE_VERSION }} \
+            sh -c "deps install flanksource/canary-checker --bin-dir /usr/bin && canary-checker run /fixtures/${{ matrix.image }}.yaml"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Run the container
-        run: |
-          docker run --pull=never --rm flanksource/base-image-canary-checker:${{ env.RELEASE_VERSION }} echo 'hello world'
-
-      - name: Ensure uv and bun are installed
-        run: |
-          docker run --pull=never --rm flanksource/base-image:${{ env.RELEASE_VERSION }} sh -lc "uv --version && bun --version"
-
-      - name: Ensure uv and bun are installed in canary-checker image
-        run: |
-          docker run --pull=never --rm flanksource/base-image-canary-checker:${{ env.RELEASE_VERSION }} sh -lc "uv --version && bun --version"
-
-  docker-build-arm64:
-    runs-on: ubuntu-24.04-arm
-
-    steps:
-      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
-
-      - name: Set version
-        # Set a random release version
-        run: |
-          echo "RELEASE_VERSION=$(tr -dc 0-9 </dev/urandom | head -c 4)" >> $GITHUB_ENV
-
-      - name: Set up Docker Buildx #must be executed before a step that contains platforms
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build base image for multiple platforms
-        # Need to build for 2 platforms in 2 stages even though --platform=linux/amd64,linux/arm64 is possible.
-        # This is because --load isn't compatible when multiple args are passed to --platform.
-        #   https://github.com/docker/buildx/issues/59
-        # We want --load to save the image to local registry.
-        run: |
-          docker buildx build --load --platform linux/arm64 --cache-from type=gha --cache-to type=gha,mode=max --secret id=GITHUB_TOKEN,env=GITHUB_TOKEN -t flanksource/base-image:${{ env.RELEASE_VERSION }} .
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Run the container
-        run: |
-          docker run --pull=never --rm flanksource/base-image:${{ env.RELEASE_VERSION }} echo 'hello world'
-
-      - name: Build canary checker base image for multiple platforms
-        run: |
-          docker buildx build --load --platform linux/arm64 --cache-from type=gha --cache-to type=gha,mode=max --secret id=GITHUB_TOKEN,env=GITHUB_TOKEN -f Dockerfile.canary-checker -t flanksource/base-image-canary-checker:${{ env.RELEASE_VERSION }} .
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Run the container
-        run: |
-          docker run --pull=never --rm flanksource/base-image-canary-checker:${{ env.RELEASE_VERSION }} echo 'hello world'
-
-      - name: Ensure uv and bun are installed
-        run: |
-          docker run --pull=never --rm flanksource/base-image:${{ env.RELEASE_VERSION }} sh -lc "uv --version && bun --version"
-
-      - name: Ensure uv and bun are installed in canary-checker image
-        run: |
-          docker run --pull=never --rm flanksource/base-image-canary-checker:${{ env.RELEASE_VERSION }} sh -lc "uv --version && bun --version"

--- a/Dockerfile.canary-checker
+++ b/Dockerfile.canary-checker
@@ -61,12 +61,6 @@ RUN curl -L https://github.com/restic/restic/releases/download/v${RESTIC_VERSION
   mv /app/restic /usr/local/bin/ && \
   rm -rf /app/restic.bz2
 
-# Mergestat
-# Unsupported in arm64 as of yet
-RUN curl -L https://github.com/flanksource/askgit/releases/download/v0.61.0-flanksource.1/mergestat-linux-amd64.tar.gz  -o mergestat.tar.gz && \
-  tar zxf mergestat.tar.gz -C /usr/local/bin/ && \
-  rm mergestat.tar.gz
-
 # K6
 ENV K6_VERSION=v0.47.0
 RUN curl -L https://github.com/grafana/k6/releases/download/${K6_VERSION}/k6-${K6_VERSION}-linux-${TARGETARCH}.tar.gz -o k6.tar.gz && \
@@ -76,9 +70,3 @@ RUN curl -L https://github.com/grafana/k6/releases/download/${K6_VERSION}/k6-${K
 
 # Benthos: high performance and resilient stream processor
 RUN curl -Lsf https://sh.benthos.dev | bash -s -- 4.22.0
-
-# dsq: commandline tool for running SQL queries against JSON, CSV, Excel, Parquet, and more
-RUN curl -L https://github.com/multiprocessio/dsq/releases/download/v0.23.0/dsq-linux-x64-v0.23.0.zip -o dsq.zip && \
-  unzip -q dsq.zip && \
-  mv dsq /usr/local/bin/dsq && \
-  rm dsq.zip

--- a/Dockerfile.canary-checker
+++ b/Dockerfile.canary-checker
@@ -43,7 +43,7 @@ ENV JAVA_HOME=/opt/java
 ENV JMETER_HOME=/opt/jmeter
 COPY --from=jre /javaruntime $JAVA_HOME
 COPY --from=jre /usr/lib/sdkman/candidates/jmeter/current /opt/jmeter
-ENV PATH="${JAVA_HOME}/bin:${JMETER_HOME}/bin:${PATH}"
+ENV PATH="${JAVA_HOME}/bin:${JMETER_HOME}/bin:/root/.local/bin:${PATH}"
 
 RUN curl -sL https://github.com/flanksource/deps/releases/latest/download/deps-linux-${TARGETARCH}.tar.gz -o deps-linux-${TARGETARCH}.tar.gz  && \
   tar -xzf deps-linux-${TARGETARCH}.tar.gz -C /usr/bin && \

--- a/fixtures/selftest/base-image-canary-checker.yaml
+++ b/fixtures/selftest/base-image-canary-checker.yaml
@@ -8,35 +8,47 @@ spec:
     - name: java
       description: "Java is available"
       script: java --version | head -1
+      display:
+        expr: 'results.stderr + results.stdout'
       test:
         expr: 'results.exitCode == 0'
 
     - name: jmeter
       description: "JMeter is available"
-      script: jmeter --version 2>&1 | head -1
+      script: jmeter --version 2>&1 | grep -i jmeter | head -1
+      display:
+        expr: 'results.stderr + results.stdout'
       test:
-        expr: 'results.stdout.contains("Apache JMeter") || results.stderr.contains("Apache JMeter")'
+        expr: 'results.exitCode == 0'
 
     - name: restic
       description: "restic is available"
       script: restic version
+      display:
+        expr: 'results.stderr + results.stdout'
       test:
         expr: 'results.stdout.contains("restic")'
 
     - name: k6
       description: "k6 is available"
       script: k6 version
+      display:
+        expr: 'results.stderr + results.stdout'
       test:
         expr: 'results.stdout.contains("k6")'
 
     - name: benthos
       description: "benthos is available"
       script: benthos --version
+      display:
+        expr: 'results.stderr + results.stdout'
       test:
         expr: 'results.exitCode == 0'
 
     - name: pipenv
       description: "pipenv is available"
-      script: pipenv --version
+      script: /home/canary-checker/.local/bin/pipenv --version
+      display:
+        expr: 'results.stderr + results.stdout'
       test:
         expr: 'results.stdout.contains("pipenv")'

--- a/fixtures/selftest/base-image-canary-checker.yaml
+++ b/fixtures/selftest/base-image-canary-checker.yaml
@@ -47,7 +47,7 @@ spec:
 
     - name: pipenv
       description: "pipenv is available"
-      script: /home/canary-checker/.local/bin/pipenv --version
+      script: pipenv --version
       display:
         expr: 'results.stderr + results.stdout'
       test:

--- a/fixtures/selftest/base-image-canary-checker.yaml
+++ b/fixtures/selftest/base-image-canary-checker.yaml
@@ -1,0 +1,42 @@
+apiVersion: canaries.flanksource.com/v1
+kind: Canary
+metadata:
+  name: base-image-canary-checker-selftest
+spec:
+  schedule: "@every 5m"
+  exec:
+    - name: java
+      description: "Java is available"
+      script: java --version | head -1
+      test:
+        expr: 'results.exitCode == 0'
+
+    - name: jmeter
+      description: "JMeter is available"
+      script: jmeter --version 2>&1 | head -1
+      test:
+        expr: 'results.stdout.contains("Apache JMeter") || results.stderr.contains("Apache JMeter")'
+
+    - name: restic
+      description: "restic is available"
+      script: restic version
+      test:
+        expr: 'results.stdout.contains("restic")'
+
+    - name: k6
+      description: "k6 is available"
+      script: k6 version
+      test:
+        expr: 'results.stdout.contains("k6")'
+
+    - name: benthos
+      description: "benthos is available"
+      script: benthos --version
+      test:
+        expr: 'results.exitCode == 0'
+
+    - name: pipenv
+      description: "pipenv is available"
+      script: pipenv --version
+      test:
+        expr: 'results.stdout.contains("pipenv")'

--- a/fixtures/selftest/base-image.yaml
+++ b/fixtures/selftest/base-image.yaml
@@ -8,6 +8,8 @@ spec:
     - name: shell
       description: "Shell script execution"
       script: echo "hello-world"
+      display:
+        expr: 'results.stderr + results.stdout'
       test:
         expr: 'results.stdout == "hello-world"'
 
@@ -17,107 +19,143 @@ spec:
       env:
         - name: TEST_VAR
           value: "env-test-passed"
+      display:
+        expr: 'results.stderr + results.stdout'
       test:
         expr: 'results.stdout == "env-test-passed"'
 
     - name: curl
       description: "curl is available"
       script: curl --version | head -1
+      display:
+        expr: 'results.stderr + results.stdout'
       test:
         expr: 'results.stdout.contains("curl")'
 
     - name: jq
       description: "jq is available"
       script: echo '{"test":"value"}' | jq -r '.test'
+      display:
+        expr: 'results.stderr + results.stdout'
       test:
         expr: 'results.stdout == "value"'
 
     - name: git
       description: "git is available"
       script: git --version
+      display:
+        expr: 'results.stderr + results.stdout'
       test:
         expr: 'results.stdout.contains("git version")'
 
     - name: kubectl
       description: "kubectl is available"
       script: kubectl version --client -o yaml | head -1
+      display:
+        expr: 'results.stderr + results.stdout'
       test:
         expr: 'results.exitCode == 0'
 
     - name: helm
       description: "helm is available"
       script: helm version --short
+      display:
+        expr: 'results.stderr + results.stdout'
       test:
         expr: 'results.exitCode == 0'
 
     - name: aws
       description: "AWS CLI is available"
       script: aws --version
+      display:
+        expr: 'results.stderr + results.stdout'
       test:
         expr: 'results.stdout.contains("aws-cli")'
 
     - name: python
       description: "Python is available"
       script: python3 --version
+      display:
+        expr: 'results.stderr + results.stdout'
       test:
         expr: 'results.stdout.contains("Python")'
 
     - name: uv
       description: "uv is available"
       script: uv --version
+      display:
+        expr: 'results.stderr + results.stdout'
       test:
         expr: 'results.stdout.contains("uv")'
 
     - name: bun
       description: "bun is available"
       script: bun --version
+      display:
+        expr: 'results.stderr + results.stdout'
       test:
         expr: 'results.exitCode == 0'
 
     - name: pwsh
       description: "PowerShell is available"
       script: pwsh --version
+      display:
+        expr: 'results.stderr + results.stdout'
       test:
         expr: 'results.stdout.contains("PowerShell")'
 
     - name: az
       description: "Azure CLI is available"
       script: az --version | head -1
+      display:
+        expr: 'results.stderr + results.stdout'
       test:
         expr: 'results.stdout.contains("azure-cli")'
 
     - name: gcloud
       description: "Google Cloud CLI is available"
       script: gcloud --version | head -1
+      display:
+        expr: 'results.stderr + results.stdout'
       test:
         expr: 'results.stdout.contains("Google Cloud SDK")'
 
     - name: yq
       description: "yq is available"
       script: yq --version
+      display:
+        expr: 'results.stderr + results.stdout'
       test:
         expr: 'results.exitCode == 0'
 
     - name: sops
       description: "sops is available"
       script: sops --version
+      display:
+        expr: 'results.stderr + results.stdout'
       test:
         expr: 'results.exitCode == 0'
 
     - name: stern
       description: "stern is available"
       script: stern --version
+      display:
+        expr: 'results.stderr + results.stdout'
       test:
         expr: 'results.exitCode == 0'
 
     - name: flux
       description: "flux is available"
       script: flux --version
+      display:
+        expr: 'results.stderr + results.stdout'
       test:
         expr: 'results.exitCode == 0'
 
     - name: fblog
       description: "fblog is available"
       script: fblog --version
+      display:
+        expr: 'results.stderr + results.stdout'
       test:
         expr: 'results.exitCode == 0'

--- a/fixtures/selftest/base-image.yaml
+++ b/fixtures/selftest/base-image.yaml
@@ -1,0 +1,123 @@
+apiVersion: canaries.flanksource.com/v1
+kind: Canary
+metadata:
+  name: base-image-selftest
+spec:
+  schedule: "@every 5m"
+  exec:
+    - name: shell
+      description: "Shell script execution"
+      script: echo "hello-world"
+      test:
+        expr: 'results.stdout == "hello-world"'
+
+    - name: env
+      description: "Environment variable handling"
+      script: echo -n "${TEST_VAR}"
+      env:
+        - name: TEST_VAR
+          value: "env-test-passed"
+      test:
+        expr: 'results.stdout == "env-test-passed"'
+
+    - name: curl
+      description: "curl is available"
+      script: curl --version | head -1
+      test:
+        expr: 'results.stdout.contains("curl")'
+
+    - name: jq
+      description: "jq is available"
+      script: echo '{"test":"value"}' | jq -r '.test'
+      test:
+        expr: 'results.stdout == "value"'
+
+    - name: git
+      description: "git is available"
+      script: git --version
+      test:
+        expr: 'results.stdout.contains("git version")'
+
+    - name: kubectl
+      description: "kubectl is available"
+      script: kubectl version --client -o yaml | head -1
+      test:
+        expr: 'results.exitCode == 0'
+
+    - name: helm
+      description: "helm is available"
+      script: helm version --short
+      test:
+        expr: 'results.exitCode == 0'
+
+    - name: aws
+      description: "AWS CLI is available"
+      script: aws --version
+      test:
+        expr: 'results.stdout.contains("aws-cli")'
+
+    - name: python
+      description: "Python is available"
+      script: python3 --version
+      test:
+        expr: 'results.stdout.contains("Python")'
+
+    - name: uv
+      description: "uv is available"
+      script: uv --version
+      test:
+        expr: 'results.stdout.contains("uv")'
+
+    - name: bun
+      description: "bun is available"
+      script: bun --version
+      test:
+        expr: 'results.exitCode == 0'
+
+    - name: pwsh
+      description: "PowerShell is available"
+      script: pwsh --version
+      test:
+        expr: 'results.stdout.contains("PowerShell")'
+
+    - name: az
+      description: "Azure CLI is available"
+      script: az --version | head -1
+      test:
+        expr: 'results.stdout.contains("azure-cli")'
+
+    - name: gcloud
+      description: "Google Cloud CLI is available"
+      script: gcloud --version | head -1
+      test:
+        expr: 'results.stdout.contains("Google Cloud SDK")'
+
+    - name: yq
+      description: "yq is available"
+      script: yq --version
+      test:
+        expr: 'results.exitCode == 0'
+
+    - name: sops
+      description: "sops is available"
+      script: sops --version
+      test:
+        expr: 'results.exitCode == 0'
+
+    - name: stern
+      description: "stern is available"
+      script: stern --version
+      test:
+        expr: 'results.exitCode == 0'
+
+    - name: flux
+      description: "flux is available"
+      script: flux --version
+      test:
+        expr: 'results.exitCode == 0'
+
+    - name: fblog
+      description: "fblog is available"
+      script: fblog --version
+      test:
+        expr: 'results.exitCode == 0'


### PR DESCRIPTION
## Summary
- Add selftest fixtures to verify all tools are properly installed in base images
- Remove dsq and mergestat from canary-checker image (amd64-only tools, not cross-platform)
- Refactor test workflow to use matrix strategy for architecture/image combinations
- Install canary-checker via deps tool and run fixtures in CI

## Changes
- `fixtures/selftest/base-image.yaml` - Tests for base-image tools (shell, curl, jq, git, kubectl, helm, aws, python, uv, bun, pwsh, az, gcloud, yq, sops, stern, flux, fblog)
- `fixtures/selftest/base-image-canary-checker.yaml` - Tests for canary-checker specific tools (java, jmeter, restic, k6, benthos, pipenv)
- `Dockerfile.canary-checker` - Removed dsq and mergestat
- `.github/workflows/test.yaml` - Matrix strategy with 4 parallel jobs (2 archs × 2 images)

## Test plan
- [ ] Verify amd64 base-image tests pass
- [ ] Verify amd64 base-image-canary-checker tests pass
- [ ] Verify arm64 base-image tests pass
- [ ] Verify arm64 base-image-canary-checker tests pass